### PR TITLE
Nancy 0.23 no longer contains Fragment in their Url class.

### DIFF
--- a/Nancy.LightningCache/CacheKey/DefaultCacheKeyGenerator.cs
+++ b/Nancy.LightningCache/CacheKey/DefaultCacheKeyGenerator.cs
@@ -50,7 +50,6 @@ namespace Nancy.LightningCache.CacheKey
             var url = new Url
             {
                 BasePath = request.Url.BasePath,
-                Fragment = request.Url.Fragment,
                 HostName = request.Url.HostName,
                 Path = request.Url.Path,
                 Port = request.Url.Port,


### PR DESCRIPTION
I removed the Fragment property from the Url constructor because Nancy 0.23 removed Fragment.  See new documentation from NancyFX/Nancy@3649d8af5922452ec836b52627a4f0111aed9306
